### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,13 @@ function handleDownload(button) {
     button.classList.add("counting-down");
 
     const link = button.getAttribute("data-link");
-    if (!link) {
-        alert("Download link not available!");
+    try {
+        const url = new URL(link, window.location.origin); // Validate and parse the URL
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+           throw new Error("Invalid protocol");
+        }
+    } catch (e) {
+        alert("Invalid download link!");
         button.classList.remove("counting-down");
         return;
     }
@@ -23,7 +28,7 @@ function handleDownload(button) {
             clearInterval(timer);
             button.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Preparing...`;
             setTimeout(() => {
-                window.location.href = link;
+                window.location.href = link; // Safe to use after validation
                 button.innerHTML = originalHTML;
                 button.disabled = false;
                 button.classList.remove("counting-down");


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/auto-website-visitor/security/code-scanning/3](https://github.com/nayandas69/auto-website-visitor/security/code-scanning/3)

To fix the issue, we need to validate and sanitize the `link` variable before using it. Specifically:
1. Ensure that the `link` value is a valid URL.
2. Use the `URL` constructor to parse and validate the URL. This will throw an error if the URL is invalid.
3. Optionally, restrict the URL to specific domains or protocols (e.g., `https`).

The changes will involve:
- Adding validation logic for the `link` variable before it is used in `window.location.href`.
- Ensuring that invalid or malicious URLs are rejected with an appropriate error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
