### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ function handleDownload(button) {
             clearInterval(timer);
             button.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Preparing...`;
             setTimeout(() => {
-                window.location.href = link; // Safe to use after validation
+                const sanitizedLink = encodeURI(link); // Sanitize the URL
+                window.location.href = sanitizedLink; // Safe to use after sanitization
                 button.innerHTML = originalHTML;
                 button.disabled = false;
                 button.classList.remove("counting-down");


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/auto-website-visitor/security/code-scanning/4](https://github.com/nayandas69/auto-website-visitor/security/code-scanning/4)

To fix the issue, we need to ensure that the `link` value is sanitized and validated before being used. The current validation using the `URL` constructor and protocol check is a good start, but we should also ensure that the `link` value is not directly derived from user-controlled attributes without additional safeguards. Instead of directly using `window.location.href = link`, we can use a safer approach by encoding the URL or ensuring it matches a predefined whitelist of allowed domains or paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
