### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/auto-website-visitor/security/code-scanning/5](https://github.com/nayandas69/auto-website-visitor/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient. This block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job.

The best approach is to add the `permissions` block at the root level of the workflow to ensure consistency and reduce redundancy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
