### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/auto-website-visitor/security/code-scanning/6](https://github.com/nayandas69/auto-website-visitor/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily reads repository contents and uploads artifacts, so the `contents: read` permission is sufficient. If any specific steps require additional permissions, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
